### PR TITLE
Add Zed Editor MCP server setup instructions

### DIFF
--- a/src/content/docs/packages/semble/mcp-server.mdx
+++ b/src/content/docs/packages/semble/mcp-server.mdx
@@ -57,6 +57,20 @@ command = "uvx"
 args = ["--from", "semble[mcp]", "semble"]
 ```
 
+### Zed
+
+1. Open **MCP Servers** → **Add Custom Server...** → **Local**
+2. Paste:
+
+```json
+{
+  "semble": {
+    "command": "uvx",
+    "args": ["--from", "semble[mcp]", "semble", "mcp"]
+  }
+}
+```
+
 ## Tools
 
 Once connected, the agent has access to two tools:


### PR DESCRIPTION
# Summary

Adds a new **Zed** section to the MCP Server documentation with:

- UI setup instructions
- JSON configuration example
- correct `mcp` subcommand usage for Zed

This aligns the Zed setup flow with the existing integrations for:

- Claude Code
- Cursor
- OpenCode
- Codex

---

# Changes

## Added

- New `Zed` section in `mcp-server.mdx`
- Step-by-step setup instructions:
  - Open MCP Servers
  - Add Custom Server
  - Select Local
- Ready-to-paste JSON configuration example

## Zed Configuration

```json
{
  "semble": {
    "command": "uvx",
    "args": ["--from", "semble[mcp]", "semble", "mcp"]
  }
}
```

---

# Important Detail

Unlike Cursor/OpenCode/Codex integrations, Zed requires the MCP server to be started with the explicit `mcp` subcommand.

Without it, the process exits immediately and Zed displays:

```text
Context server stopped running
```

This update documents the correct configuration and improves the onboarding experience for Zed users.

---

# Tested

- Zed MCP local server flow
- MCP server connection
- `uvx --from "semble[mcp]" semble mcp`
- Custom server setup through the Zed UI